### PR TITLE
fix(deps): Revert main Azure Application Gateway Orchestrator extension .NET project to .NET 6 from .NET 8.

### DIFF
--- a/AzureAppGatewayOrchestrator/AzureAppGatewayOrchestrator.csproj
+++ b/AzureAppGatewayOrchestrator/AzureAppGatewayOrchestrator.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>AzureApplicationGatewayOrchestratorExtension</RootNamespace>
     <AssemblyName>AzureApplicationGatewayOrchestratorExtension</AssemblyName>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,6 @@
   - feat(certauth): Implement client certificate authentication as an alternative authentication mechanism.
   - chore(docs): Update documentation to discuss the Key Vault Azure role-based access control permission model.
   - fix(akv): Refactor Azure Key Vault certificate retrieval mechanism to recognize and appropriately handle secret versions.
+
+- 3.1.0
+  - fix(deps): Revert main Azure Application Gateway Orchestrator extension .NET project to .NET 6 from .NET 8.


### PR DESCRIPTION
- 3.1.0
  - fix(deps): Revert main Azure Application Gateway Orchestrator extension .NET project to .NET 6 from .NET 8.